### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ Download with notebooks:
 coursera-helper --cauth <CAUTH> --download-notebooks <COURSE NAME>
 ```
 
+Download without skipping any urls:
+
+```
+coursera-helper --cauth <CAUTH> --disable-url-skipping <COURSE NAME>
+```
+
 ### Use configuration file
 
 Alternatively, if you want to store your preferred parameters (which might also include your username and password), create a file named `coursera-dl.conf` where the script is supposed to be executed, with the following format:


### PR DESCRIPTION
## Proposed changes

When we download the courses using the coursera-helper, sometimes some links dont get downloaded. Coursera-helper does show a command ```--disable-url-skipping``` but then we again have to run the whole command of downloading the course. 
So knowing it beforehand seems to be helpful, hence I think adding it to the <b>More Download Options</b> section of the readme.md file.
